### PR TITLE
delete context.identifier in VisitMethodCallExpression

### DIFF
--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -289,8 +289,8 @@ export class Visitor{
 					context.query[context.identifier] = new RegExp("^" + context.literal, "gi");
 					break;
 			}
+			delete context.identifier;
 		}
-		delete context.identifier;
 	}
 
 }

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -290,6 +290,7 @@ export class Visitor{
 					break;
 			}
 		}
+		delete context.identifier;
 	}
 
 }

--- a/test/visitor.spec.js
+++ b/test/visitor.spec.js
@@ -105,6 +105,10 @@ describe("mongodb visitor", () => {
       expect(f).to.deep.eql({ A: /BC/gi });
   })
 
+  it("expression 5.1.1.4.1: contains(A, 'BC') or contains(D, 'EF')", () => {
+      expect(f).to.deep.eql({ $or: [{ A: /BC/gi }, { D: /EF/gi }]});
+  })
+
   it("expression 5.1.1.4.2: endswith(A, 'CD')", () => {
       expect(f).to.deep.eql({ A: /CD$/gi });
   })


### PR DESCRIPTION
After creating a new test that or'ed two method together, I ended up what looked like the second function concatenating the previous ODataIdentifier.value.name. I noticed in a few places where the current state was reset by a delete call, so I applied it after the query creation method and the following test that was failing  passed along with all the others that were passing prior to my change (see failure in PS).

1. It seems like the following test fails:
 mongodb visitor expression 5.1.1.6.1: DurationValue eq duration'P12DT23H59M59.999999999999S'

```
AssertionError: expected { DurationValue: -1612801000 } to deeply equal { DurationValue: 1033199000 }
      + expected - actual

       {
      -  "DurationValue": -1612801000
      +  "DurationValue": 1033199000
       }
```

2. My new test copied the value 5.1.1.4.1 which may be wrong

Thanks for the great library!

```
2) mongodb visitor expression 5.1.1.4.1: contains(A, 'BC') or contains(D, 'EF'):

      AssertionError: expected { Object ($or) } to deeply equal { Object ($or) }
      + expected - actual

           {
             "A": /BC/gi
           }
           {
      -      "AD": /EF/gi
      +      "D": /EF/gi
           }
         ]
       }
```