### PR TITLE
Fix for Equals Expression and tolower OData function

### DIFF
--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -220,7 +220,8 @@ export class Visitor{
 		this.Visit(node.value.left, context);
 		this.Visit(node.value.right, context);
 
-		if (context.identifier) context.query[context.identifier] = context.literal;
+		// using object with $eq instead of just value assigned to identifier we resolve an issue with OData: not (documentStatus eq 'OPEN')
+		if (context.identifier) context.query[context.identifier] = { $eq: context.literal };
 		delete context.identifier;
 		delete context.literal;
 	}
@@ -288,6 +289,12 @@ export class Visitor{
 				case "startswith":
 					context.query[context.identifier] = new RegExp("^" + context.literal, "gi");
 					break;
+				case "tolower":
+					// mongoDb is case insensitive as default, so it should resolve 99% cases I hope - better than exception I think?
+					// $toLower function is implemented only for agregation in MongoDb
+					// using object with $eq instead of just value assigned to identifier we resolve an issue with OData: not (documentStatus eq 'OPEN')
+                    context.query[context.identifier] = { $eq: context.literal };
+                    break;
 				default:
 					throw new Error("Method call not implemented.")
 			}

--- a/test/visitor.spec.js
+++ b/test/visitor.spec.js
@@ -22,15 +22,15 @@ describe("mongodb visitor", () => {
   })
 
   it("expression 5.1.1.6.1: NullValue eq null", () => {
-      expect(f).to.deep.eql({ NullValue: null })
+      expect(f).to.deep.eql({ NullValue: { $eq: null } })
   })
 
   it("expression 5.1.1.6.1: TrueValue eq true", () => {
-      expect(f).to.deep.eql({ TrueValue: true })
+      expect(f).to.deep.eql({ TrueValue: { $eq: true } })
   })
 
   it("expression 5.1.1.6.1: FalseValue eq false", () => {
-      expect(f).to.deep.eql({ FalseValue: false })
+      expect(f).to.deep.eql({ FalseValue: { $eq: false } })
   })
 
   it("expression 5.1.1.6.1: IntegerValue lt -128", () => {
@@ -38,39 +38,39 @@ describe("mongodb visitor", () => {
   })
 
   it("expression 5.1.1.6.1: DecimalValue eq 34.95", () => {
-      expect(f).to.deep.eql({ DecimalValue: 34.95 })
+      expect(f).to.deep.eql({ DecimalValue: { $eq: 34.95 } })
   })
 
   it("expression 5.1.1.6.1: StringValue eq 'Say Hello,then go'", () => {
-      expect(f).to.deep.eql({ StringValue: 'Say Hello,then go' })
+      expect(f).to.deep.eql({ StringValue: { $eq: 'Say Hello,then go' } })
   })
 
   xit("expression 5.1.1.6.1: DurationValue eq duration'P12DT23H59M59.999999999999S'", () => {
-      expect(f).to.deep.eql({ DurationValue: 1033199000 })
+      expect(f).to.deep.eql({ DurationValue: { $eq: 1033199000 } })
   })
 
   it("expression 5.1.1.6.1: DateValue eq 2012-12-03", () => {
-      expect(f).to.deep.eql({ DateValue: '2012-12-03' })
+      expect(f).to.deep.eql({ DateValue: { $eq: '2012-12-03' } })
   })
 
   it("expression 5.1.1.6.1: DateTimeOffsetValue eq 2012-12-03T07:16:23Z", () => {
-      expect(f).to.deep.eql({ DateTimeOffsetValue: new Date('2012-12-03T07:16:23Z') })
+      expect(f).to.deep.eql({ DateTimeOffsetValue: { $eq: new Date('2012-12-03T07:16:23Z') } })
   })
 
   it("expression 5.1.1.6.1: GuidValue eq 01234567-89ab-cdef-0123-456789abcdef", () => {
-      expect(f).to.deep.eql({ GuidValue: '01234567-89ab-cdef-0123-456789abcdef' })
+      expect(f).to.deep.eql({ GuidValue: { $eq: '01234567-89ab-cdef-0123-456789abcdef' } })
   })
 
   it("expression 5.1.1.6.1: Int64Value eq 0", () => {
-      expect(f).to.deep.eql({ Int64Value: 0 })
+      expect(f).to.deep.eql({ Int64Value: { $eq: 0 } })
   })
 
   it("expression 5.1.1.6.1: A eq INF", () => {
-      expect(f).to.deep.eql({ A: Infinity })
+      expect(f).to.deep.eql({ A: { $eq: Infinity } })
   })
 
   it("expression 5.1.1.6.1: A eq 0.31415926535897931e1", () => {
-      expect(f).to.deep.eql({ A: 0.31415926535897931e1 })
+      expect(f).to.deep.eql({ A: { $eq: 0.31415926535897931e1 } })
   })
 
   it("expression 5.1.1.1.2: A ne 1", () => {
@@ -94,11 +94,11 @@ describe("mongodb visitor", () => {
   })
 
   it("expression: A/b eq 1", () => {
-      expect(f).to.deep.eql({ 'A.b': 1 })
+      expect(f).to.deep.eql({ 'A.b': { $eq: 1 } })
   })
 
   it("expression 5.1.1.3: (A/b eq 2) or (B/c lt 4) and ((E gt 5) or (E lt -1))", () => {
-      expect(f).to.deep.eql({ $or: [{ 'A.b': 2 }, { $and: [{ 'B.c': { $lt: 4 } }, { $or: [{ E: { $gt: 5 } }, { E: { $lt: -1 } }] }] }] })
+      expect(f).to.deep.eql({ $or: [{ 'A.b': { $eq: 2 } }, { $and: [{ 'B.c': { $lt: 4 } }, { $or: [{ E: { $gt: 5 } }, { E: { $lt: -1 } }] }] }] })
   })
 
   it("expression 5.1.1.4.1: contains(A, 'BC')", () => {


### PR DESCRIPTION
Hi,

We are using you module and it works great, but recent changes implemented by another extensions broke it and we have implemented 2 fixes:

- Parsing correctly filter like: not (documentStatus eq 'OPEN'), current version parsing it to: documentStatus: not 'OPEN'
- handling tolower OData function