### PR TITLE
Fix for Equals and notEquals Expressions. Added Support for toLower and toUpper Functions.

### DIFF
--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -220,7 +220,7 @@ export class Visitor{
 		this.Visit(node.value.left, context);
 		this.Visit(node.value.right, context);
 
-		if (context.identifier) context.query[context.identifier] = context.literal;
+		if (context.identifier) context.query[context.identifier] = { $eq: context.literal };
 		delete context.identifier;
 		delete context.literal;
 	}
@@ -281,6 +281,7 @@ export class Visitor{
 			switch (method) {
 				case "contains":
 					context.query[context.identifier] = new RegExp(context.literal, "gi");
+					delete context.identifier;
 					break;
 				case "endswith":
 					context.query[context.identifier] = new RegExp(context.literal + "$", "gi");
@@ -288,10 +289,15 @@ export class Visitor{
 				case "startswith":
 					context.query[context.identifier] = new RegExp("^" + context.literal, "gi");
 					break;
+				case "tolower":
+					context.query[context.identifier] = new RegExp(context.literal, "gi");
+					break;
+				case "toupper":
+					context.query[context.identifier] = new RegExp(context.literal, "gi");
+					break;
 				default:
 					throw new Error("Method call not implemented.")
 			}
-			delete context.identifier;
 		}
 	}
 

--- a/test/visitor.spec.js
+++ b/test/visitor.spec.js
@@ -11,7 +11,7 @@ describe("mongodb visitor", () => {
   });
 
   //all numbers are referencing this:
-  //http://docs.oasis-open.org/odata/odata/v4.0/errata02/os/complete/part2-url-conventions/odata-v4.0-errata02-os-part2-url-conventions-complete.html#_Toc406398116
+  //https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#_Toc31361028
 
   it("expression: 1 eq 1", () => {
       expect(f).to.deep.eql({})
@@ -21,56 +21,56 @@ describe("mongodb visitor", () => {
       expect(f).to.deep.eql({})
   })
 
-  it("expression 5.1.1.6.1: NullValue eq null", () => {
-      expect(f).to.deep.eql({ NullValue: null })
+  it("expression 5.1.1.14.1: NullValue eq null", () => {
+      expect(f).to.deep.eql({ NullValue: {$eq: null} })
   })
 
-  it("expression 5.1.1.6.1: TrueValue eq true", () => {
-      expect(f).to.deep.eql({ TrueValue: true })
+  it("expression 5.1.1.14.1: TrueValue eq true", () => {
+      expect(f).to.deep.eql({ TrueValue: {$eq: true} })
   })
 
-  it("expression 5.1.1.6.1: FalseValue eq false", () => {
-      expect(f).to.deep.eql({ FalseValue: false })
+  it("expression 5.1.1.14.1: FalseValue eq false", () => {
+      expect(f).to.deep.eql({ FalseValue: {$eq: false} })
   })
 
-  it("expression 5.1.1.6.1: IntegerValue lt -128", () => {
+  it("expression 5.1.1.14.1: IntegerValue lt -128", () => {
       expect(f).to.deep.eql({ IntegerValue: { $lt: -128 } })
   })
 
-  it("expression 5.1.1.6.1: DecimalValue eq 34.95", () => {
-      expect(f).to.deep.eql({ DecimalValue: 34.95 })
+  it("expression 5.1.1.14.1: DecimalValue eq 34.95", () => {
+      expect(f).to.deep.eql({ DecimalValue: {$eq: 34.95} })
   })
 
-  it("expression 5.1.1.6.1: StringValue eq 'Say Hello,then go'", () => {
-      expect(f).to.deep.eql({ StringValue: 'Say Hello,then go' })
+  it("expression 5.1.1.14.1: StringValue eq 'Say Hello,then go'", () => {
+      expect(f).to.deep.eql({ StringValue: {$eq: 'Say Hello,then go'} })
   })
 
-  xit("expression 5.1.1.6.1: DurationValue eq duration'P12DT23H59M59.999999999999S'", () => {
-      expect(f).to.deep.eql({ DurationValue: 1033199000 })
+  xit("expression 5.1.1.14.1: DurationValue eq duration'P12DT23H59M59.999999999999S'", () => {
+      expect(f).to.deep.eql({ DurationValue: {$eq: 1033199000} })
   })
 
-  it("expression 5.1.1.6.1: DateValue eq 2012-12-03", () => {
-      expect(f).to.deep.eql({ DateValue: '2012-12-03' })
+  it("expression 5.1.1.14.1: DateValue eq 2012-12-03", () => {
+      expect(f).to.deep.eql({ DateValue: {$eq: '2012-12-03'} })
   })
 
-  it("expression 5.1.1.6.1: DateTimeOffsetValue eq 2012-12-03T07:16:23Z", () => {
-      expect(f).to.deep.eql({ DateTimeOffsetValue: new Date('2012-12-03T07:16:23Z') })
+  it("expression 5.1.1.14.1: DateTimeOffsetValue eq 2012-12-03T07:16:23Z", () => {
+      expect(f).to.deep.eql({ DateTimeOffsetValue: {$eq: new Date('2012-12-03T07:16:23Z')} })
   })
 
-  it("expression 5.1.1.6.1: GuidValue eq 01234567-89ab-cdef-0123-456789abcdef", () => {
-      expect(f).to.deep.eql({ GuidValue: '01234567-89ab-cdef-0123-456789abcdef' })
+  it("expression 5.1.1.14.1: GuidValue eq 01234567-89ab-cdef-0123-456789abcdef", () => {
+      expect(f).to.deep.eql({ GuidValue: {$eq: '01234567-89ab-cdef-0123-456789abcdef'} })
   })
 
-  it("expression 5.1.1.6.1: Int64Value eq 0", () => {
-      expect(f).to.deep.eql({ Int64Value: 0 })
+  it("expression 5.1.1.14.1: Int64Value eq 0", () => {
+      expect(f).to.deep.eql({ Int64Value: {$eq: 0 } })
   })
 
-  it("expression 5.1.1.6.1: A eq INF", () => {
-      expect(f).to.deep.eql({ A: Infinity })
+  it("expression 5.1.1.14.1: A eq INF", () => {
+      expect(f).to.deep.eql({ A: {$eq: Infinity } })
   })
 
-  it("expression 5.1.1.6.1: A eq 0.31415926535897931e1", () => {
-      expect(f).to.deep.eql({ A: 0.31415926535897931e1 })
+  it("expression 5.1.1.14.1: A eq 0.31415926535897931e1", () => {
+      expect(f).to.deep.eql({ A: {$eq: 0.31415926535897931e1 } })
   })
 
   it("expression 5.1.1.1.2: A ne 1", () => {
@@ -94,11 +94,11 @@ describe("mongodb visitor", () => {
   })
 
   it("expression: A/b eq 1", () => {
-      expect(f).to.deep.eql({ 'A.b': 1 })
+      expect(f).to.deep.eql({ 'A.b': {$eq: 1 } })
   })
 
   it("expression 5.1.1.3: (A/b eq 2) or (B/c lt 4) and ((E gt 5) or (E lt -1))", () => {
-      expect(f).to.deep.eql({ $or: [{ 'A.b': 2 }, { $and: [{ 'B.c': { $lt: 4 } }, { $or: [{ E: { $gt: 5 } }, { E: { $lt: -1 } }] }] }] })
+      expect(f).to.deep.eql({ $or: [{ 'A.b': { $eq: 2 } }, { $and: [{ 'B.c': { $lt: 4 } }, { $or: [{ E: { $gt: 5 } }, { E: { $lt: -1 } }] }] }] })
   })
 
   it("expression 5.1.1.4.1: contains(A, 'BC')", () => {
@@ -109,15 +109,55 @@ describe("mongodb visitor", () => {
       expect(f).to.deep.eql({ $or: [{ A: /BC/gi }, { D: /EF/gi }]});
   })
 
-  it("expression 5.1.1.4.2: endswith(A, 'CD')", () => {
+  it("expression 5.1.1.5.3: endswith(A, 'CD')", () => {
       expect(f).to.deep.eql({ A: /CD$/gi });
   })
 
-  it("expression 5.1.1.4.3: startswith(A, 'CD')", () => {
+  it("expression 5.1.1.5.6: startswith(A, 'CD')", () => {
       expect(f).to.deep.eql({ A: /^CD/gi });
   })
 
-  it("expression 5.1.1.1.11: not endswith(Name,'ilk')", () => {
+  it("expression 5.1.1.1.12: not endswith(Name,'ilk')", () => {
       expect(f).to.deep.eql({ Name: { $not: /ilk$/gi } });
+  })
+
+  it("expression 5.1.1.7.2: tolower(displayName) eq 'device1'", () => {
+      expect(f).to.deep.eql({ displayName: { $eq: 'device1'} });
+  })
+
+  it("expression 5.1.1.7.3: toupper(displayName) eq 'device1'", () => {
+      expect(f).to.deep.eql({ displayName: { $eq: 'device1'} });
+  })
+
+  it("expression 5.1.1.1.9: not (displayName eq 'device1')", () => {
+      expect(f).to.deep.eql({ displayName: { $not: { $eq: 'device1'} } });
+  })
+
+  it("expression 5.1.1.1.9: not (tolower(displayName) eq 'device1')", () => {
+      expect(f).to.deep.eql({ displayName: { $not: { $eq: 'device1'} } });
+  })
+
+  it("expression 5.1.1.1.9: not (toupper(displayName) eq 'device1')", () => {
+      expect(f).to.deep.eql({ displayName: { $not: { $eq: 'device1'} } });
+  })
+
+  it("expression 5.1.1.7.2: tolower(displayName) ne 'device1'", () => {
+      expect(f).to.deep.eql({displayName: {$ne: 'device1'}});
+  })
+
+  it("expression 5.1.1.7.3: toupper(displayName) ne 'device1'", () => {
+      expect(f).to.deep.eql({ displayName: { $ne: 'device1'} });
+  })
+
+  it("expression 5.1.1.1.9: not (displayName ne 'device1')", () => {
+      expect(f).to.deep.eql({ displayName: { $not: { $ne: 'device1'} } });
+  })
+
+  it("expression 5.1.1.1.9: not (tolower(displayName) ne 'device1')", () => {
+      expect(f).to.deep.eql({ displayName: { $not: { $ne: 'device1'} } });
+  })
+
+  it("expression 5.1.1.1.9: not (toupper(displayName) ne 'device1')", () => {
+      expect(f).to.deep.eql({ displayName: { $not: { $ne: 'device1'} } });
   })
 })


### PR DESCRIPTION
Hi, 

I stumbled across your package and found it useful for oData to MongoDB conversions. My main problem with it however arose from the lack of toUpper and toLower function support. 

From this pull request: https://github.com/jaystack/odata-v4-mongodb/pull/11. As the pull request has been lying dormant I added in support for these methods (and associated tests) and as our database is case sensitive, I effectively pass them straight through. Happy to discuss an alternative for these functions. I also ran into an issue where the context identifier was being deleted after a method so it couldn't be used in any other operation. The only case I saw that this was needed was for the contains method. Again happy to discuss this. 

I updated the test expression numbers to the newest documentation I could find while I was at it. https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#_Toc31361028

- Added toUpper and toLower Function support.

- Fixed an issue where the Method Call was prematurely removing context identifier for use in other functions. 

- Updated test expression numbers to oDatav4.0.1 documentation. 

- Added tests to support the toLower, toUpper and not functions.